### PR TITLE
大佬，发现您的项目引入了org.webjars:bootstrap@3.3.7组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -35,7 +34,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.3.7</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Bootstrap跨站脚本漏洞
缺陷组件：org.webjars:bootstrap@3.3.7
漏洞编号：CVE-2018-20677
漏洞描述：Bootstrap是一款使用HTML、CSS和JavaScript开发的开源Web前端框架。
Bootstrap 3.4.0之前版本中的affix存在跨站脚本漏洞，远程攻击者可利用该漏洞注入任意的Web脚本或HTML。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2019-23270
影响范围：(∞, 3.4.0)
最小修复版本：3.4.1
缺陷组件引入路径：com.hendisantika.reactive:springboot-sse-reactive@0.0.1-SNAPSHOT->org.webjars:bootstrap@3.3.7
```
另外我运行这个项目时，IDE的安全插件提示还有5个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pe9138